### PR TITLE
Fix new image insertion

### DIFF
--- a/data/cli-test-references/test_cache_basic.reference
+++ b/data/cli-test-references/test_cache_basic.reference
@@ -34,8 +34,8 @@ ikup cache list
 {{.*}}/earth.jpg (mtime: {{.*}})
   JPEG 100x80 {{\d*}} [[earth_cache_path]]
 {{.*}}/ruler.png (mtime: {{.*}})
-  JPEG 200x11 {{\d*}} [[ruler_cache_path]]
   JPEG 100x5 {{\d*}} [[ruler_cache_path_100]]
+  JPEG 200x11 {{\d*}} [[ruler_cache_path]]
 {{.*}}/tux.png (mtime: {{.*}})
   PNG 64x75 {{\d*}} [[tux_cache_path]]
 

--- a/data/cli-test-references/test_cache_check.reference
+++ b/data/cli-test-references/test_cache_check.reference
@@ -140,13 +140,6 @@ Bytes: {{.*}}
 cp ./.cli-tests-data/butterfly.jpg [[butterfly_cache2]]
 The next command should return another error
 ikup cache check ./.cli-tests-data/butterfly.jpg --max-bytes 8000 --format png
-Cached: [[butterfly_cache2]]
-Format: PNG
-Size: {{.*}}
-Bytes: {{.*}}
-Error: Cached image size {{.*}} bytes exceeds requested max_bytes {{.*}}
-Error: Format mismatch: db entry PNG, file JPEG
-Error: Width mismatch: db entry {{.*}}
-Error: Height mismatch: db entry {{.*}}
+Not cached
 Exit code: 1
 

--- a/data/cli-test-references/test_cache_max_bytes.reference
+++ b/data/cli-test-references/test_cache_max_bytes.reference
@@ -28,9 +28,9 @@ ikup cache convert ./.cli-tests-data/earth.jpg --max-bytes 4500 --format png
 [[earth_4500_cache:.*]]
 ikup cache list ./.cli-tests-data/earth.jpg
 {{.*}}/earth.jpg (mtime: {{.*}})
-  JPEG 240x240 [[earth_large_size]] [[earth_large_cache]]
-  PNG [[earth_5k_dims:.*]] [[earth_5k_size:[0-9]+]] [[earth_5k_cache]]
   PNG [[earth_4500_dims:.*]] [[earth_4500_size:[0-9]+]] [[earth_4500_cache]]
+  PNG [[earth_5k_dims:.*]] [[earth_5k_size:[0-9]+]] [[earth_5k_cache]]
+  JPEG 240x240 [[earth_large_size]] [[earth_large_cache]]
 {{:ASSERT: 4750 <= int(earth_5k_size) <= 5000}}
 {{:ASSERT: 4250 <= int(earth_4500_size) <= 4500}}
 
@@ -49,8 +49,8 @@ ikup cache convert ./.cli-tests-data/transparency.png --max-bytes 94000
 [[transparency_94k_cache:.*]]
 ikup cache list ./.cli-tests-data/transparency.png
 {{.*}}/transparency.png (mtime: {{.*}})
-  PNG [[transparency_10k_dims:.*]] [[transparency_10k_size:[0-9]+]] [[transparency_100k_cache]]
   PNG [[transparency_94k_dims:.*]] [[transparency_94k_size:[0-9]+]] [[transparency_94k_cache]]
+  PNG [[transparency_10k_dims:.*]] [[transparency_10k_size:[0-9]+]] [[transparency_100k_cache]]
 {{:ASSERT: 95000 <= int(transparency_10k_size) <= 100000}}
 {{:ASSERT: 89000 <= int(transparency_94k_size) <= 94000}}
 

--- a/ikup/cli.py
+++ b/ikup/cli.py
@@ -822,7 +822,7 @@ def cache_convert(
         height=height,
         max_size_bytes=max_bytes,
     )
-    print(cached_image.path)
+    print(cached_image.dst_path)
 
 
 def cache_remove(
@@ -891,7 +891,7 @@ def cache_list(
         # Filter to only show specified images
         images_abs = [os.path.abspath(img) for img in images if os.path.exists(img)]
         cached_images = [
-            cached for cached in cached_images if cached.path in images_abs
+            cached for cached in cached_images if cached.src_path in images_abs
         ]
 
     if not cached_images:
@@ -902,13 +902,13 @@ def cache_list(
         return
 
     for source_image in cached_images:
-        mtime_str = source_image.mtime.isoformat()
-        print(f"{source_image.path} (mtime: {mtime_str})")
+        mtime_str = source_image.src_mtime.isoformat()
+        print(f"{source_image.src_path} (mtime: {mtime_str})")
         for converted in source_image.converted_images:
             size_str = f"{converted.width}x{converted.height}"
             bytes_str = f"{converted.size_bytes}"
             print(
-                f"  {converted.format.upper()} {size_str} {bytes_str} {converted.path}"
+                f"  {converted.format.upper()} {size_str} {bytes_str} {converted.dst_path}"
             )
 
 
@@ -949,7 +949,7 @@ def cache_check(
         print("Not cached", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Cached: {cached_image.path}")
+    print(f"Cached: {cached_image.dst_path}")
     print(f"Format: {cached_image.format}")
     print(f"Size: {cached_image.width}x{cached_image.height}")
     print(f"Bytes: {cached_image.size_bytes}")
@@ -972,16 +972,16 @@ def cache_check(
     actual_format = None
     actual_width = None
     actual_height = None
-    file_exists = os.path.exists(cached_image.path)
+    file_exists = os.path.exists(cached_image.dst_path)
 
     if not file_exists:
         errors = True
     else:
-        actual_size_bytes = os.path.getsize(cached_image.path)
+        actual_size_bytes = os.path.getsize(cached_image.dst_path)
         try:
             from PIL import Image
 
-            image_object = Image.open(cached_image.path)
+            image_object = Image.open(cached_image.dst_path)
             actual_width, actual_height = image_object.size
             actual_format = (image_object.format or "UNKNOWN").upper()
         except Exception as e:


### PR DESCRIPTION
Insert a new entry before copying/saving the file to avoid orphan files in the cache directory.